### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,5 @@
   "devDependencies": {
     "whiskey": "0.8.x"
   },
-  "licenses": [
-    {
-      "type": "Apache",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-    }
-  ]
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/