### PR TITLE
Replace Dead EFF-Bot Links with Python.org Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Installation
 Using the library
 ====================
 
-For the usage refer to the Python ElementTree library documentation - [http://effbot.org/zone/element-index.htm#usage](http://effbot.org/zone/element-index.htm#usage).
+For the usage refer to the Python ElementTree library documentation - [https://docs.python.org/3/library/xml.etree.elementtree.html](https://docs.python.org/3/library/xml.etree.elementtree.html).
 
-Supported XPath expressions in `find`, `findall` and `findtext` methods are listed on [http://effbot.org/zone/element-xpath.htm](http://effbot.org/zone/element-xpath.htm).
+Supported XPath expressions in `find`, `findall` and `findtext` methods are listed on [https://docs.python.org/3/library/xml.etree.elementtree.html#supported-xpath-syntax](https://docs.python.org/3/library/xml.etree.elementtree.html#supported-xpath-syntax).
 
 Example 1 – Creating An XML Document
 ====================


### PR DESCRIPTION
The EFF-Bot website has been down for some time now, so the links in the README (which are also used on [npm](https://www.npmjs.com/package/elementtree)) no longer resolve properly. While the EFF-Bot website is indeed preserved at the Internet Archive, the corresponding documentation at Python.org is a bit easier to work with.

If you prefer the Internet Archive version, though, the links would be as follows:

* https://web.archive.org/web/20200323073515/http://effbot.org/zone/element-index.htm#usage
* https://web.archive.org/web/20200429175514/http://effbot.org/zone/element-xpath.htm